### PR TITLE
Cast as int

### DIFF
--- a/gen_anchors.py
+++ b/gen_anchors.py
@@ -102,7 +102,7 @@ def run_kmeans(ann_dims, anchor_num):
 
 def main(argv):
     config_path = args.conf
-    num_anchors = args.anchors
+    num_anchors = int(args.anchors)
 
     with open(config_path) as config_buffer:
         config = json.loads(config_buffer.read())


### PR DESCRIPTION
Calling `python gen_anchors.py -c config.json --anchors=3` errors out as below:
```
Traceback (most recent call last):
  File "gen_anchors.py", line 138, in <module>
    main(args)
  File "gen_anchors.py", line 130, in main
    centroids = run_kmeans(annotation_dims, num_anchors)
  File "gen_anchors.py", line 72, in run_kmeans
    old_distances = np.zeros((ann_num, anchor_num))
TypeError: 'str' object cannot be interpreted as an integer
```

This is because [argparse](https://docs.python.org/2/library/argparse.html) casts command line inputs as strings. This PR fixes the problem by casting them as an `int` within the `main` method.